### PR TITLE
A simple secp256k1 context object with no precomputed tables

### DIFF
--- a/include/secp256k1.h
+++ b/include/secp256k1.h
@@ -179,6 +179,13 @@ typedef int (*secp256k1_nonce_function)(
 #define SECP256K1_TAG_PUBKEY_HYBRID_EVEN 0x06
 #define SECP256K1_TAG_PUBKEY_HYBRID_ODD 0x07
 
+/** A simple secp256k1 context object with no precomputed tables. These are useful for
+ *  type serialization/parsing functions which require a context object to maintain
+ *  API consistency, but currently do not require expensive precomputations or dynamic
+ *  allocations.
+ */
+SECP256K1_API extern const secp256k1_context *secp256k1_context_no_precomp;
+
 /** Create a secp256k1 context object.
  *
  *  Returns: a newly created context object.
@@ -221,6 +228,21 @@ SECP256K1_API void secp256k1_context_destroy(
  *  When this callback is triggered, the API function called is guaranteed not
  *  to cause a crash, though its return value and output arguments are
  *  undefined.
+ *
+ *  When this function has not been called (or called with fn==NULL), then the
+ *  default handler will be used. The library provides a default handler which
+ *  writes the message to stderr and calls abort. This default handler can be
+ *  replaced at link time if the preprocessor macro
+ *  USE_EXTERNAL_DEFAULT_CALLBACKS is defined, which is the case if the build
+ *  has been configured with --enable-external-default-callbacks. Then the
+ *  following two symbols must be provided to link against:
+ *   - void secp256k1_default_illegal_callback_fn(const char* message, void* data);
+ *   - void secp256k1_default_error_callback_fn(const char* message, void* data);
+ *  The library can call these default handlers even before a proper callback data
+ *  pointer could have been set using secp256k1_context_set_illegal_callback or
+ *  secp256k1_context_set_illegal_callback, e.g., when the creation of a context
+ *  fails. In this case, the corresponding default handler will be called with
+ *  the data pointer argument set to NULL.
  *
  *  Args: ctx:  an existing context object (cannot be NULL)
  *  In:   fun:  a pointer to a function to call when an illegal argument is

--- a/src/tests.c
+++ b/src/tests.c
@@ -3699,6 +3699,7 @@ void run_ec_pubkey_parse_test(void) {
     ecount = 0;
     VG_UNDEF(&pubkey, sizeof(pubkey));
     CHECK(secp256k1_ec_pubkey_parse(ctx, &pubkey, pubkeyc, 65) == 1);
+    CHECK(secp256k1_ec_pubkey_parse(secp256k1_context_no_precomp, &pubkey, pubkeyc, 65) == 1);
     VG_CHECK(&pubkey, sizeof(pubkey));
     CHECK(ecount == 0);
     VG_UNDEF(&ge, sizeof(ge));


### PR DESCRIPTION
Pick an object `secp256k1_context_no_precomp` from https://github.com/rust-bitcoin/rust-secp256k1 repository, for an easy-life feature: A simple secp256k1 context object with no precomputed tables.

This is quite useful for type serialization/parsing functions which require a context object to maintain API consistency, but currently do not require expensive precomputations or dynamic allocations.

The main picking sources:
- https://github.com/rust-bitcoin/rust-secp256k1/blob/secp256k1-sys-0.3.0/secp256k1-sys/depend/secp256k1/include/secp256k1.h#L186-L191
- https://github.com/rust-bitcoin/rust-secp256k1/blob/secp256k1-sys-0.3.0/secp256k1-sys/depend/secp256k1/src/secp256k1.c#L35-L57
- #L77-L83

and these:
- #L162
- #L170
- #L179
- https://github.com/rust-bitcoin/rust-secp256k1/blob/secp256k1-sys-0.3.0/secp256k1-sys/depend/secp256k1/src/tests.c#L3885



